### PR TITLE
Fix mobile hamburger menu styling

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -176,6 +176,21 @@ body {
                 }
             }
         }
+
+        // Fix for mobile hamburger menu - override minima's white background
+        @media screen and (max-width: 600px) {
+            background-color: $primary-color !important;
+            border: 1px solid rgba(255, 255, 255, 0.2) !important;
+            
+            .page-link {
+                color: white !important;
+                
+                &:hover {
+                    color: #f0f0f0 !important;
+                    background-color: rgba(255, 255, 255, 0.1);
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- Override minima's white background with primary blue color
- Ensure proper contrast for mobile menu links
- Add hover effects for better mobile UX
- Applies to screens 600px and below